### PR TITLE
Remove extra quote

### DIFF
--- a/src/epub/text/chapter-4-8-7.xhtml
+++ b/src/epub/text/chapter-4-8-7.xhtml
@@ -114,7 +114,7 @@
 					<p>“Never!”</p>
 					<p>At the tone in which that “never” was uttered, Marius lost all hope. He traversed the chamber with slow steps, with bowed head, tottering and more like a dying man than like one merely taking his departure. <abbr>M.</abbr> Gillenormand followed him with his eyes, and at the moment when the door opened, and Marius was on the point of going out, he advanced four paces, with the senile vivacity of impetuous and spoiled old gentlemen, seized Marius by the collar, brought him back energetically into the room, flung him into an armchair and said to him:⁠—</p>
 					<p>“Tell me all about it!”</p>
-					<p>“It was that single word ‘father’ which had effected this revolution.</p>
+					<p>It was that single word ‘father’ which had effected this revolution.</p>
 					<p>Marius stared at him in bewilderment. <abbr>M.</abbr> Gillenormand’s mobile face was no longer expressive of anything but rough and ineffable good-nature. The grandsire had given way before the grandfather.</p>
 					<p>“Come, see here, speak, tell me about your love affairs, jabber, tell me everything! Sapristi! how stupid young folks are!”</p>
 					<p>“Father⁠—” repeated Marius.</p>


### PR DESCRIPTION
I believe the quote at the beginning of the second line is wrong.

> "It was that single word (...)

![extra-quote](https://user-images.githubusercontent.com/12852780/106272626-3eb28480-6229-11eb-861c-d943589b008c.png)
